### PR TITLE
add new reducer state to keep track of when user is authenticated

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { Router } from 'react-router';
 import { Switch, Route } from 'react-router-dom';
 import createHistory from 'history/createBrowserHistory';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 import NavMenu from './common/nav-menu';
 import NavHeader from './common/nav-header';
 import Products from './products';
@@ -17,20 +19,61 @@ const {
   home, register, products, product, login,
 } = ROUTES;
 
-const App = () => (
-  <Router history={history}>
-    <div className="app-container">
-      <NavMenu />
-      <NavHeader history={history} />
-      <Switch>
-        <Route exact path={home} component={Home} />
-        <Route exact path={products} component={Products} />
-        <Route exact path={product} component={Product} />
-        <Route exact path={register} component={Register} />
-        <Route exact path={login} component={Login} />
-      </Switch>
-    </div>
-  </Router>
-);
+class App extends Component {
+  render() {
+    const { authenticationState, loginState } = this.props;
+    const token = localStorage.getItem('OS_AUTH_TOKEN');
+    // if there is no token, there is no need to validate. If there is an status code on any of
+    // authenticationState or loginState, then the token has been validated.
+    const isTokenValidated = !token || !!authenticationState.statusCode || !!loginState.statusCode;
+    const isAuthenticated = authenticationState.statusCode === 200 || loginState.statusCode === 200;
+    // will be re-used for the cart component
+    const authenticationProps = {
+      isTokenValidated,
+      isAuthenticated,
+    };
 
-export default App;
+    return (
+      <Router history={history}>
+        <div className="app-container">
+          <NavMenu {...authenticationProps} />
+          <NavHeader history={history} />
+          <Switch>
+            <Route exact path={home} component={Home} />
+            <Route exact path={products} component={Products} />
+            <Route exact path={product} component={Product} />
+            <Route exact path={register} component={Register} />
+            <Route exact path={login} component={Login} />
+          </Switch>
+        </div>
+      </Router>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  authenticationState: state.authentication,
+  loginState: state.login,
+});
+
+
+App.propTypes = {
+  authenticationState: PropTypes.shape({
+    statusCode: PropTypes.number,
+    data: PropTypes.shape({
+      id: PropTypes.string,
+      exp: PropTypes.number,
+      iat: PropTypes.number,
+    }),
+    statusText: PropTypes.string,
+  }).isRequired,
+  loginState: PropTypes.shape({
+    statusCode: PropTypes.number,
+    message: PropTypes.string,
+    statusText: PropTypes.string,
+  }).isRequired,
+};
+
+export default connect(
+  mapStateToProps,
+)(App);

--- a/src/components/common/nav-menu/index.js
+++ b/src/components/common/nav-menu/index.js
@@ -1,30 +1,57 @@
 import React, { PureComponent } from 'react';
 import { Navbar, Nav, NavItem } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
 import { ROUTES } from '../../../constants';
 
 class NavMenu extends PureComponent {
+  // eslint-disable-next-line class-methods-use-this
+  logOut() {
+    localStorage.removeItem('OS_AUTH_TOKEN');
+  }
+
   render() {
     const {
       home, register, login,
     } = ROUTES;
+    const { isTokenValidated, isAuthenticated } = this.props;
 
-    return (
-      <div className="os--nav-menu">
-        <Navbar inverse>
-          <Navbar.Header>
-            <Navbar.Brand>
-              <Link to={home}>Home</Link>
-            </Navbar.Brand>
-          </Navbar.Header>
-          <Nav pullRight>
-            <NavItem href={register}>Register</NavItem>
-            <NavItem href={login}>Login</NavItem>
-          </Nav>
-        </Navbar>
-      </div>
+    const loginItems = (
+      <Nav pullRight>
+        <NavItem href={register}>Register</NavItem>
+        <NavItem href={login}>Login</NavItem>
+      </Nav>
     );
+    const logoutItems = (
+      <Nav pullRight>
+        <NavItem href={home} onClick={() => this.logOut()}>Log out</NavItem>
+      </Nav>
+    );
+
+    let displayElem = null;
+
+    if (isTokenValidated) {
+      displayElem = (
+        <div className="os--nav-menu">
+          <Navbar inverse>
+            <Navbar.Header>
+              <Navbar.Brand>
+                <Link to={home}>Home</Link>
+              </Navbar.Brand>
+            </Navbar.Header>
+            {!isAuthenticated ? loginItems : logoutItems}
+          </Navbar>
+        </div>
+      );
+    }
+
+    return displayElem;
   }
 }
+
+NavMenu.propTypes = {
+  isTokenValidated: PropTypes.bool.isRequired,
+  isAuthenticated: PropTypes.bool.isRequired,
+};
 
 export default NavMenu;

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import { createStore, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
 import rootReducer from './store/reducers';
 import App from './components/app';
+import validateToken from './store/actions/validate-token';
 import apiRequestMiddleware from './store/middleware/api-request';
 
 /* eslint-disable no-underscore-dangle */
@@ -17,6 +18,12 @@ const store = createStore(
   ),
 );
 /* eslint-enable */
+
+// validate the token stored in the local storage
+const token = localStorage.getItem('OS_AUTH_TOKEN');
+if (token) {
+  store.dispatch(validateToken(token));
+}
 
 ReactDOM.render(
   <Provider store={store}>

--- a/src/store/actions/types.js
+++ b/src/store/actions/types.js
@@ -12,3 +12,5 @@ export const FETCH_PRODUCT = asyncActionType('FETCH_PRODUCT');
 export const REGISTER = asyncActionType('REGISTER');
 
 export const LOGIN = asyncActionType('LOGIN');
+
+export const VALIDATE_TOKEN = asyncActionType('VERIFY_TOKEN');

--- a/src/store/actions/validate-token.js
+++ b/src/store/actions/validate-token.js
@@ -1,0 +1,12 @@
+import { VALIDATE_TOKEN, API_REQUEST } from './types';
+
+const validateToken = token => ({
+  type: API_REQUEST,
+  payload: {
+    ...VALIDATE_TOKEN,
+    endpoint: `users/validate-token/${token}`,
+    method: 'GET',
+  },
+});
+
+export default validateToken;

--- a/src/store/reducers/authentication.js
+++ b/src/store/reducers/authentication.js
@@ -1,0 +1,16 @@
+import { VALIDATE_TOKEN } from '../actions/types';
+import { getInitialState } from '../../utils';
+
+const authentication = (state = getInitialState(), action) => {
+  switch (action.type) {
+    case VALIDATE_TOKEN.SUCCESS:
+      return action.payload;
+    case VALIDATE_TOKEN.FAILURE:
+      localStorage.removeItem('OS_AUTH_TOKEN');
+      return action.payload;
+    default:
+      return state;
+  }
+};
+
+export default authentication;

--- a/src/store/reducers/index.js
+++ b/src/store/reducers/index.js
@@ -4,6 +4,7 @@ import products from './products';
 import product from './product';
 import register from './register';
 import login from './login';
+import authentication from './authentication';
 
 const rootReducer = combineReducers({
   products,
@@ -11,6 +12,7 @@ const rootReducer = combineReducers({
   form,
   register,
   login,
+  authentication,
 });
 
 export default rootReducer;


### PR DESCRIPTION
# Description

This PR implements the follow:
1 - Add a new reducer called `authentication` which keeps track of whether the current token stored in the local storage is valid or not.

# Test

# 1- Set-up/run the server and web app  first
#### Backend
Set-up backend server and start the server
0 - Checkout feature branch `git checkout add-endpoint-for-token-validation`.
1 - Install latest dependencies `npm i`.
2 - Set the required environment variable `JWT_SECRET` by creating a `.env` file in the main directory and set your secret in that file ie. `JWT_SECRET=HELLO`.
3 - run the app using `npm run start`. If you want to skip step 2, you can set the env with `JWT_SECRET=HELLO npm run start`.

#### Front-end
Set-up frontend webapp and start the app:
0 - Checkout this feature branch `git checkout add-reducer-state-to-keep-track-of-authentication`.
1 - Install latest dependencies `npm i`.
2 - run the app using `npm run start`.

# 2- After the server and web app have been started, navigate to the login page by clicking on the login button. Login with your credentials that you used last time or use the following one:
```
email: test@gmail.com
password: test@gmail.com
```

Upong logging in, the `logout` button should now appear. 

If you do a refresh on the website, the `logout` button should still remain there. It makes a call to the end-point I created in https://github.com/AntonioLok/online-shopping-reactJS-Backend/pull/12 and basically checks that the token is valid. If it's valid, the token will remain in the local storage and the `logout` button will stay. Otherwise if it's invalid, the token will be removed and the `register/login` button will appear.

Now you can click on `logout` button which should bring back the `register/login` button and the token is removed.

To check for invalid tokens: set a new item in the local storage with key `OS_AUTH_TOKEN` mapped to some "invalid" token. You can do this by opening the console and type in:
`localStorage.setItem('OS_AUTH_TOKEN', 'fake-token');`. Now if you do a refresh, the app will make a call to the end-point I created in the backend. Since the token is invalid, the action type in the reducer should be `VALIDATE_TOKEN.FAILURE` which removes the token and so the `logout` button is not displayed.

You can test expired, malformed token using samples listed in my back-end PR.

# Next to do
Work on the cart component (both backend and frontend)