### PR TITLE
refactor: improve implementation to render fields

### DIFF
--- a/src/components/common/form/index.js
+++ b/src/components/common/form/index.js
@@ -6,12 +6,14 @@ import { connect } from 'react-redux';
 import Button from './button';
 import TextInput from './input-fields/text-input';
 import SelectInput from './input-fields/select-input';
+import { FIELDS_TYPE } from '../../../constants';
 
 class CustomForm extends PureComponent {
   render() {
     const {
       title, handleSubmit, submitButtonProps, inputFields,
     } = this.props;
+    const { TEXT_INPUT } = FIELDS_TYPE;
 
     const emailTextInput = (
       <TextInput
@@ -32,17 +34,17 @@ class CustomForm extends PureComponent {
     );
 
     const inputFieldArray = inputFields.map((field) => {
-      if (field.textInput) {
-        if (field.textInput.name === 'email') {
+      if (field.type === TEXT_INPUT) {
+        if (field.name === 'email') {
           return emailTextInput;
         }
-        if (field.textInput.name === 'password') {
+        if (field.name === 'password') {
           return passwordTextInput;
         }
         // Custom field input
-        return <TextInput {...field.textInput} />;
+        return <TextInput {...field} />;
       }
-      return <SelectInput {...field.selectInput} />;
+      return <SelectInput {...field} />;
     });
 
     return (

--- a/src/components/product/add-to-cart-form.js
+++ b/src/components/product/add-to-cart-form.js
@@ -14,7 +14,10 @@ class AddToCartForm extends PureComponent {
 AddToCartForm.propTypes = {
   inputFields: PropTypes.array,
   handleSubmit: PropTypes.func.isRequired,
-  submitButtonProps: PropTypes.array,
+  submitButtonProps: PropTypes.shape({
+    icon: PropTypes.string,
+    caption: PropTypes.string.isRequired,
+  }),
 };
 
 export default reduxForm({ form: 'AddToCartForm' })(AddToCartForm);

--- a/src/components/product/index.js
+++ b/src/components/product/index.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import AddToCartForm from './add-to-cart-form';
 import fetchProduct from '../../store/actions/product';
+import { FIELDS_TYPE } from '../../constants';
 
 class Product extends Component {
   constructor() {
@@ -38,6 +39,7 @@ class Product extends Component {
   }
 
   render() {
+    const { SELECT_INPUT } = FIELDS_TYPE;
     const { productState } = this.props;
     const product = productState.data;
     const { sizeAvailable } = product;
@@ -54,12 +56,18 @@ class Product extends Component {
       },
       inputFields: [
         {
-          selectInput: {
-            name: 'selectSize',
-            options: sizeAvailable,
-            validate: ['required'],
-            placeholder: 'Please select a size',
-          },
+          type: SELECT_INPUT,
+          name: 'selectSize',
+          options: sizeAvailable,
+          validate: ['required'],
+          placeholder: 'Please select a size',
+        },
+        {
+          type: SELECT_INPUT,
+          name: 'selectAmount',
+          options: [1, 2, 3, 4, 5],
+          validate: ['required'],
+          placeholder: 'Please select an amount',
         },
       ],
     };

--- a/src/components/user/login/index.js
+++ b/src/components/user/login/index.js
@@ -6,7 +6,9 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 import login from '../../../store/actions/login';
-import { ROUTES, FORM_STATUS_RESPONSE_MESSAGE, FALLBACK_ERROR_MESSAGE_FORM } from '../../../constants';
+import {
+  ROUTES, FORM_STATUS_RESPONSE_MESSAGE, FALLBACK_ERROR_MESSAGE_FORM, FIELDS_TYPE,
+} from '../../../constants';
 import CustomForm from '../../common/form';
 
 class Login extends Component {
@@ -30,6 +32,7 @@ class Login extends Component {
   }
 
   render() {
+    const { TEXT_INPUT } = FIELDS_TYPE;
     const { loginState } = this.props;
     const { statusCode } = loginState;
     const { home } = ROUTES;
@@ -39,8 +42,8 @@ class Login extends Component {
       onSubmit: this.handleSubmit,
       form: 'LoginForm',
       inputFields: [
-        { textInput: { name: 'email' } },
-        { textInput: { name: 'password' } },
+        { type: TEXT_INPUT, name: 'email' },
+        { type: TEXT_INPUT, name: 'password' },
       ],
     };
 

--- a/src/components/user/register/index.js
+++ b/src/components/user/register/index.js
@@ -6,7 +6,9 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 import register from '../../../store/actions/register';
-import { ROUTES, FORM_STATUS_RESPONSE_MESSAGE, FALLBACK_ERROR_MESSAGE_FORM } from '../../../constants';
+import {
+  ROUTES, FORM_STATUS_RESPONSE_MESSAGE, FALLBACK_ERROR_MESSAGE_FORM, FIELDS_TYPE,
+} from '../../../constants';
 import CustomForm from '../../common/form';
 import asyncValidate from '../../../utils/email-exists';
 
@@ -31,6 +33,7 @@ class Register extends Component {
   }
 
   render() {
+    const { TEXT_INPUT } = FIELDS_TYPE;
     const { registerState } = this.props;
     const { statusCode } = registerState;
     const { login } = ROUTES;
@@ -43,8 +46,8 @@ class Register extends Component {
       asyncValidate,
       asyncBlurFields: ['email'],
       inputFields: [
-        { textInput: { name: 'email' } },
-        { textInput: { name: 'password' } },
+        { type: TEXT_INPUT, name: 'email' },
+        { type: TEXT_INPUT, name: 'password' },
       ],
     };
 

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -34,3 +34,8 @@ export const FALLBACK_ERROR_MESSAGE_FORM = 'An unknown error has occurred. Pleas
 export const SUCCESS = 'SUCCESS';
 
 export const FAILURE = 'FAILURE';
+
+export const FIELDS_TYPE = {
+  TEXT_INPUT: 'TEXT_INPUT',
+  SELECT_INPUT: 'SELECT_INPUT',
+};


### PR DESCRIPTION
# Description
This PR implements the follow:
1 - Refactor the structure of the fields passed to the HOC form.
2 - Add a new select field to the `add-to-cart-form` so users can select how many of `x` products they would like to add to their cart:
![image](https://user-images.githubusercontent.com/14690224/66879966-bc984100-ef8e-11e9-8440-71f493754d2b.png)

# Test
### Backend
1 - Start server. Instructions on how to set it up and start it are provided in here https://github.com/AntonioLok/online-shopping-reactJS-Backend/blob/master/README.md

### Frontend
2 - Checkout this branch `git checkout refactor-form`.
3 - Install latest dep using `npm i`.
4 - Start web-app with `npm run start`.
5 - Since the code is updating the forms, we will need to test that the register, login and the form to add product to the cart.
6 - For register, navigate to  `http://localhost:8080/register` and create a new account
7 - If the register was successful, the app should have redirected you to to `http://localhost:8080/login`. Please log in using the same credentials as 6. To check that you were able to log in successfully, in the console , type in `localStorage.getItem('OS_AUTH_TOKEN');` to get the token. You should get a token in the console.
8 - For the add-to-cart-form, navigate to `http://localhost:8080/product/5d5862eded2c408c4225626f` and select a size and an amount. Then click on the `add product` button. Then in the console, type in `localStorage.getItem('cart')`. The product that you added to your cart should be returned as a string.

# To do after:
- More PRs coming up for the cart component