### PR TITLE
chore SSF-5: update proptypes for object to use shape

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -134,6 +134,7 @@ App.propTypes = {
       img: PropTypes.string,
       name: PropTypes.string,
       price: PropTypes.number,
+      sizeAvailable: PropTypes.arrayOf(PropTypes.string),
     })),
     statusText: PropTypes.string,
   }).isRequired,

--- a/src/components/cart/cart-products.js
+++ b/src/components/cart/cart-products.js
@@ -78,6 +78,7 @@ CartProducts.propTypes = {
     img: PropTypes.string,
     name: PropTypes.string,
     price: PropTypes.number,
+    sizeAvailable: PropTypes.arrayOf(PropTypes.string),
   }).isRequired,
   cartProducts: PropTypes.arrayOf(PropTypes.shape({
     _id: PropTypes.string,
@@ -86,6 +87,7 @@ CartProducts.propTypes = {
     img: PropTypes.string,
     name: PropTypes.string,
     price: PropTypes.number,
+    sizeAvailable: PropTypes.arrayOf(PropTypes.string),
   })).isRequired,
   dispatchUpdateCart: PropTypes.func.isRequired,
   isAuthenticated: PropTypes.bool.isRequired,

--- a/src/components/cart/index.js
+++ b/src/components/cart/index.js
@@ -87,6 +87,7 @@ Cart.propTypes = {
     img: PropTypes.string,
     name: PropTypes.string,
     price: PropTypes.number,
+    sizeAvailable: PropTypes.arrayOf(PropTypes.string),
   })),
   isAuthenticated: PropTypes.bool.isRequired,
   updateUnauthenticatedUserCart: PropTypes.func,

--- a/src/components/common/nav-header/index.js
+++ b/src/components/common/nav-header/index.js
@@ -16,7 +16,9 @@ const NavHeader = (props) => {
 };
 
 NavHeader.propTypes = {
-  history: PropTypes.object.isRequired,
+  history: PropTypes.shape({
+    push: PropTypes.func.isRequired,
+  }).isRequired,
 };
 
 export default NavHeader;

--- a/src/components/common/nav-header/render-nav-headers.js
+++ b/src/components/common/nav-header/render-nav-headers.js
@@ -56,7 +56,9 @@ class RenderNavHeaders extends Component {
 
 RenderNavHeaders.propTypes = {
   section: PropTypes.string.isRequired,
-  history: PropTypes.object.isRequired,
+  history: PropTypes.shape({
+    push: PropTypes.func.isRequired,
+  }).isRequired,
 };
 
 export default RenderNavHeaders;

--- a/src/components/common/nav-menu/index.js
+++ b/src/components/common/nav-menu/index.js
@@ -50,6 +50,7 @@ NavMenu.propTypes = {
     img: PropTypes.string,
     name: PropTypes.string,
     price: PropTypes.number,
+    sizeAvailable: PropTypes.arrayOf(PropTypes.string),
   })),
 };
 

--- a/src/components/product/index.js
+++ b/src/components/product/index.js
@@ -122,10 +122,28 @@ const mapDispatchToProps = dispatch => ({
 });
 
 Product.propTypes = {
-  history: PropTypes.object.isRequired,
-  match: PropTypes.object.isRequired,
+  history: PropTypes.shape({
+    push: PropTypes.func.isRequired,
+  }).isRequired,
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
   dispatchFetchProduct: PropTypes.func.isRequired,
-  productState: PropTypes.object.isRequired,
+  productState: PropTypes.shape({
+    data: PropTypes.shape({
+      _id: PropTypes.string,
+      quantity: PropTypes.number,
+      size: PropTypes.string,
+      img: PropTypes.string,
+      name: PropTypes.string,
+      price: PropTypes.number,
+      sizeAvailable: PropTypes.arrayOf(PropTypes.string),
+    }),
+    statusCode: PropTypes.number,
+    statusText: PropTypes.string,
+  }).isRequired,
   cartProducts: PropTypes.arrayOf(PropTypes.shape({
     _id: PropTypes.string,
     quantity: PropTypes.number,
@@ -133,6 +151,7 @@ Product.propTypes = {
     img: PropTypes.string,
     name: PropTypes.string,
     price: PropTypes.number,
+    sizeAvailable: PropTypes.arrayOf(PropTypes.string),
   })),
   isAuthenticated: PropTypes.bool.isRequired,
   updateUnauthenticatedUserCart: PropTypes.func,

--- a/src/components/products/index.js
+++ b/src/components/products/index.js
@@ -67,10 +67,28 @@ const mapDispatchToProps = dispatch => ({
 });
 
 Products.propTypes = {
-  match: PropTypes.object.isRequired,
-  history: PropTypes.object.isRequired,
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      section: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
+  history: PropTypes.shape({
+    push: PropTypes.func.isRequired,
+  }).isRequired,
   dispatchfetchProducts: PropTypes.func.isRequired,
-  productsState: PropTypes.object.isRequired,
+  productsState: PropTypes.shape({
+    data: PropTypes.arrayOf(PropTypes.shape({
+      _id: PropTypes.string,
+      quantity: PropTypes.number,
+      size: PropTypes.string,
+      img: PropTypes.string,
+      name: PropTypes.string,
+      price: PropTypes.number,
+      sizeAvailable: PropTypes.arrayOf(PropTypes.string),
+    })),
+    statusCode: PropTypes.number,
+    statusText: PropTypes.string,
+  }).isRequired,
 };
 
 export default connect(

--- a/src/components/products/product-list.js
+++ b/src/components/products/product-list.js
@@ -41,7 +41,9 @@ class ProductList extends Component {
 }
 
 ProductList.propTypes = {
-  history: PropTypes.object.isRequired,
+  history: PropTypes.shape({
+    push: PropTypes.func.isRequired,
+  }).isRequired,
   products: PropTypes.array.isRequired,
 };
 


### PR DESCRIPTION
# Ticket
https://antoniolok.atlassian.net/browse/SSF-5

# Problem
Currently in the code base, there are some proptypes object defined as this: `PropTypes.object`. This PR updates object to shape in order to provide more details about the fields of the object.

# Test
Testing this will be a bit hard. I guess a fair test would be to open the console while browsing on the different components of the app and ensure that there are not proptypes error.

# 1- Set-up/run the server and web app  first
#### Backend
Set-up backend server and start the server:

1 - Install latest dependencies `npm i`.
2 - Set the required environment variable `JWT_SECRET` by creating a `.env` file in the main directory and set your secret in that file ie. `JWT_SECRET=HELLO`.
3 - run the app using `npm run start`. If you want to skip step 2, you can set the env with `JWT_SECRET=HELLO npm run start`.

#### Front-end
Set-up front-end web-app and start the app:
0 - Checkout this feature branch `git checkout SSF-5-update-proptype-for-objects`.
1 - Install latest dependencies `npm i`.
2 - run the app using `npm run start`.
3 - navigate on the different components