### PR TITLE
fix: SSF-6 hide dropdown when user clicks an option in the nav header

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,8 @@
 const config = {
   extends: ['@commitlint/config-conventional'],
+  rules: {
+    'subject-case': [0, 'always', 'upper-case'],
+  },
 };
 
 module.exports = config;

--- a/src/components/common/nav-header/render-nav-headers.js
+++ b/src/components/common/nav-header/render-nav-headers.js
@@ -27,6 +27,7 @@ class RenderNavHeaders extends Component {
 
   handleSelect(eventKey) {
     const { history, section } = this.props;
+    this.setState({ show: false });
     history.push(`/products/${section}/${eventKey}`);
   }
 


### PR DESCRIPTION
# Ticket
https://antoniolok.atlassian.net/secure/RapidBoard.jspa?rapidView=2&modal=detail&selectedIssue=SSF-6&quickFilter=1

# Problem
Currently, there is a bug where if the user clicks one of the categories for any section
![image](https://user-images.githubusercontent.com/14690224/68269843-4afd6100-0029-11ea-9172-30019cfe9d37.png)

the dropdown option still remains active. 

This PR fixes this bug. If a user selects an option in the dropdown, the dropdown menu should hide/go away.

# Test
# 1- Set-up/run the server and web app  first
#### Backend

Set-up backend server and start the server:
1 - Install latest dependencies `npm i`.
2 - Run server `npm run start.

#### Front-end
Set-up frontend webapp and start the app:
0 - Checkout this branch `git checkout SSF-6-fix-hide-dropdown-when-user-clicks-an-option-in-the-navigation-header`
1 - Install latest dependencies `npm i`.
2 - run the app using `npm run start`.
3 - Hover over one of the menu sections, a dropdown should appear.
![image](https://user-images.githubusercontent.com/14690224/68269947-a7608080-0029-11ea-9190-7ec19817e7a5.png)

Select one of the options. The menu should disappear. 